### PR TITLE
Adding skipRecords option

### DIFF
--- a/spec/KeyAlgorithmsAndSemantics.html
+++ b/spec/KeyAlgorithmsAndSemantics.html
@@ -6,7 +6,7 @@
     <p>Conceptually, at the heart of the EMCAScript observation mechanism is two structures:</p>
     <ul>
       <li><a href="#ChangeObservers">ChangeObservers</a>: the set of functions which are presently registered as observers of changes which take place to given object.
-      <li><a href="#PendingChangeRecords">PendingChangeRecords</a>: the sequence of change records which have been enqueued for delivery to the an observer, but not yet delivered.
+      <li><a href="#PendingChangeRecords">PendingChangeRecords</a>: the sequence of change records which have been enqueued for delivery to an observer, but not yet delivered.
     </ul>
     <p><a href="#Object.observe">Object.observe</a> enters a function into an object's associated set of ChangeObservers (while <a href="#Object.unobserve">Object.unobserve</a> removes it).</p>
 
@@ -27,7 +27,7 @@
       <li>When certain <a href="#changes_to_array_methods">mutations to Arrays</a> take place which may affect multiple index properties, observers may receive "splice" change records.
       <li>The <a href="#notifierprototype_.notify">notify()</a> method of an object's associated <a href="#notifier">Notifier</a> may be used to cause observers to receive custom ("synthetic") change records.
     </ul>
-    <p>Change records are enqueued to observers via the internal <a href="#enqueuechangerecord">EnqueueChangeRecord</a> algorithm.</p>
+    <p>Change records are enqueued to observers via the internal <a href="#EnqueueChangeRecord">EnqueueChangeRecord</a> algorithm.</p>
   </emu-clause>
   
   <emu-clause id="the-notifier-object">
@@ -40,9 +40,9 @@
   <emu-clause id="accepted-change-types">
     <h1>Accepted Change Types</h1>
 
-    <p>An observer must only receive change records whose type matches one provided in the accept list, which is passed as the (optional) third argument to <a href="#object.observe">Object.observe</a> (if the argument is not provided, the list defaults to the "intrinsic" set of change types).</p>
+    <p>An observer must only receive change records whose type matches one provided in the accept list, which is passed as the (optional) third argument to <a href="#Object.observe">Object.observe</a> (if the argument is not provided, the list defaults to the "intrinsic" set of change types).</p>
 
-    <p>An observation is conceptually a tuple: <observed object, observer function, accepted change types>. Object.observe ensures that this tuple is represented as an observerRecord in the associated Notifier's ChangeObservers list.</p>
+    <p>An observation is conceptually a tuple: &lt;observed object, observer function, accepted change types&gt;. Object.observe ensures that this tuple is represented as an observerRecord in the associated Notifier's ChangeObservers list.</p>
   </emu-clause>
 
   <emu-clause id="ActiveChanges">
@@ -50,22 +50,22 @@
 
     <p>The <a href="#notifierprototype_.performchange">performChange()</a> method of an object's associated Notifier provides a mechanism to describe a set of changes as a single (more compact) higher-level change type.</p>
 
-    <p>The set of change types being performed on an object is represented in the set of properties of the Notifier's <a href="#beginchange">BeginChange</a> before, and <a href="#endchange">EndChange</a> after invoking the provided changeFn function.</p>
+    <p>The set of change types being performed on an object is represented in the set of properties of the Notifier's <a href="#BeginChange">BeginChange</a> before, and <a href="#EndChange">EndChange</a> after invoking the provided changeFn function.</p>
   </emu-clause>
 
   <emu-clause id="enqueuing-changes-to-observers">
     <h1>Enqueuing changes to observers</h1>
 
-    <p>When a change is to be enqueued to an object's associated observers, the internal <a href="#enqueuechangerecord">EnqueueChangeRecord</a> algorithm tests whether each observer should receive the change by invoking <a href="#shoulddelivertoobserver">ShouldDeliverToObserver</a>.</p>
+    <p>When a change is to be enqueued to an object's associated observers, the internal <a href="#EnqueueChangeRecord">EnqueueChangeRecord</a> algorithm tests whether each observer should receive the change by invoking <a href="#ShouldDeliverToObserver">ShouldDeliverToObserver</a>.</p>
 
     <p>ShouldDeliverToObserver returns true IFF an observer accepts the candidate change record's type, but accepts none of the change types currently being performed on the object (as represented in the ActiveChanges).</p>
   </emu-clause>
   <emu-clause id="end-of-turn-delivery-of-change-records">
     <h1>End of turn delivery of change records</h1>
-    <p>At the end of the current processing turn (or "Microtask"), <a href="#deliverallchangerecords">DeliverAllChangeRecords</a> is invoked, which continuously delivers pending change records to observers until there are none remaining.</p>
+    <p>At the end of the current processing turn (or "Microtask"), <a href="#DeliverAllChangeRecords">DeliverAllChangeRecords</a> is invoked, which continuously delivers pending change records to observers until there are none remaining.</p>
 
-    <p>The order in which observers are delivered to is maintained in the <a href="#observercallbacks">ObserverCallbacks</a> list. The first time a function is used as an observer by provided it as an argument to Object.observe, it is appended to the end of ObserverCallbacks.</p>
+    <p>The order in which observers are delivered to is maintained in the <a href="#ObserverCallbacks">ObserverCallbacks</a> list. The first time a function is used as an observer by provided it as an argument to Object.observe, it is appended to the end of ObserverCallbacks.</p>
 
-    <p>Delivery takes place by repeatedly iterating front-to-back through ObserverCallbacks, <a href="#deliverchangerecords">delivering</a> to any observer who has pending change records, until no observer have pending change records.</p>
+    <p>Delivery takes place by repeatedly iterating front-to-back through ObserverCallbacks, <a href="#DeliverChangeRecords">delivering</a> to any observer who has pending change records, until no observer have pending change records.</p>
   </emu-clause>
 </emu-clause>

--- a/spec/NewInternalsSpecification.html
+++ b/spec/NewInternalsSpecification.html
@@ -192,16 +192,21 @@
       1. Let _array_ be ArrayCreate(0).
       1. Let _n_ be 0.
       1. Let _anyFound_ be *false*.
+      1. Let _anyRecords_ be *false*.
       1. For each _record_ in _changeRecords_, do:
         1. Let _anyFound_ be *true*.
         1. If _record_ is *undefined*, continue.
+        1. Let _anyRecords_ be *true*.
         1. Let _status_ be the result of CreateDataProperty(_array_, ToString(_n_), _record_).
         1. Assert: _status_ is *true*.
         1. Increment _n_ by 1.
       1. If _anyFound_ is *false*, return *false*.
-      1. <ins>TODO(arv): Should we call with undefined if the array is empty?</ins>
-      1. Let _status_ be Call(_C_, *undefined*, «_array_»).
-      1. _result_ is intentionally ignored here since. An implementation might choose to log abrupt completions here.
+      1. If _anyRecords_ is *true*, then:
+        1. Let _arg_ be _array_.
+      1. Else,
+        1. Let _arg_ be *undefined*.
+      1. Let _status_ be Call(_C_, *undefined*, «_arg_»).
+      1. _result_ is intentionally ignored here. An implementation might choose to log abrupt completions here.
       1. Return *true*.
     </emu-alg>
 

--- a/spec/NewInternalsSpecification.html
+++ b/spec/NewInternalsSpecification.html
@@ -174,10 +174,12 @@
         1. If _deliver_ is *false*, continue.
         1. Otherwise, let _observer_ be _observerRecord_.[[Callback]].
         1. Let _pendingRecords_ be the value of _observer_'s [[PendingChangeRecords]] internal slot.
-        1. Append _changeRecord_ to the end of _pendingRecords_.
+        1. If _observerRecord_.[[Skip]] is *false*, then
+          1. Append *undefined* to the end of _pendingRecords_.
+        1. Else,
+          1. Append _changeRecord_ to the end of _pendingRecords_.
     </emu-alg>
   </emu-clause>
-
 
   <emu-clause id="DeliverChangeRecords" aoid>
     <h1>DeliverChangeRecords(C)</h1>
@@ -189,11 +191,15 @@
       1. Set _C_'s [[PendingChangeRecords]] internal slot to a new empty List.
       1. Let _array_ be ArrayCreate(0).
       1. Let _n_ be 0.
+      1. Let _anyFound_ be *false*.
       1. For each _record_ in _changeRecords_, do:
+        1. Let _anyFound_ be *true*.
+        1. If _record_ is *undefined*, continue.
         1. Let _status_ be the result of CreateDataProperty(_array_, ToString(_n_), _record_).
         1. Assert: _status_ is *true*.
         1. Increment _n_ by 1.
-      1. If _array_ is empty, return *false*.
+      1. If _anyFound_ is *false*, return *false*.
+      1. <ins>TODO(arv): Should we call with undefined if the array is empty?</ins>
       1. Let _status_ be Call(_C_, *undefined*, «_array_»).
       1. _result_ is intentionally ignored here since. An implementation might choose to log abrupt completions here.
       1. Return *true*.

--- a/spec/PublicApiSpecification.html
+++ b/spec/PublicApiSpecification.html
@@ -28,12 +28,14 @@
           1. Let _nextIndex_ be _nextIndex_ + 1.
       1. Let _skipRecordsValue_ be GetOption(_options_, `"skipRecords"`).
       1. ReturnIfAbrupt(_skipRecordsValue_).
+      1. Let _skipRecords_ be ToBoolean(_skipRecordsValue_).
       1. Let _notifier_ be GetNotifier(_O_).
       1. Let _changeObservers_ be the value of _notifier_`s [[ChangeObservers]] internal slot.
-      1. If _changeObservers_ already contains a _record_ whose _callback_ property is the same as _callback_, then
+      1. If _changeObservers_ already contains a _record_ whose [[Callback]] field is the same as _callback_, then
         1. Set _record_.[[Accept]] to _acceptList_.
+        1. Set _record_.[[Skip]] to _skipRecords_.
         1. Return _O_.
-      1. Let _observerRecord_ be Record{[[Callback]]: _callback_, [[Accept]: _acceptList_}.
+      1. Let _observerRecord_ be Record{[[Callback]]: _callback_, [[Accept]: _acceptList_, [[Skip]]: _skipRecords_}.
       1. Append _observerRecord_ to the end of the _changeObservers_ list.
       1. Let _observerCallbacks_ be [[ObserverCallbacks]].
       1. If _observerCallbacks_ already contains _callback_, return _O_.
@@ -58,9 +60,7 @@
   <emu-clause id="Array.observe">
     <h1>Array.observe(O, callback, options = undefined</h1>
 
-    <p>A new function Array.observe is added, which is equivalent to</p>
-    <!-- TODO(arv): Use a real spec algorithm here. Refactor Object.observe into
-    a new spec algorithm that is shared between these two. -->
+    <p>A new function Array.observe is added, which is equivalent to. <ins>TODO(arv) Use a real spec algorithm here. Refactor Object.observe into a new spec algorithm that is shared between these two.</ins></p>
 
     <pre>
 function(O, callback,
@@ -90,7 +90,7 @@ function(O, callback) {
 
     <p>When the `deliverChangeRecords` method is called with argument _callback_, the following steps are taken:</p>
     <emu-alg>
-      1. If IsCallable(_callback_) is *false*, throw a *TypeError* exception.
+      1. If IsCallable(_callback_) is *true*, throw a *TypeError* exception.
       1. Repeat
         1. Let _result_ be DeliverChangeRecords(_callback_).
         1. If _result_ is *false* return.


### PR DESCRIPTION
Adding support for skip option.

```js
Object.observe(object, callback {skipRecords: true})
```

When we enqueue a record we check if records should be skipped and if so we add `undefined` to the pending records. When we deliver the records we do not include the `undefined` entries.