### PR TITLE
Fix Travis failing PR from forks

### DIFF
--- a/deploy.sh
+++ b/deploy.sh
@@ -9,6 +9,10 @@ mkdir out;
 ecmarkup spec/index.html out/index.html
 cp css/elements.css out/elements.css
 
+# stop if this is a PR from a fork, since Travis disables
+# secure environment variables in that case
+test -z "${GH_TOKEN}" && exit 0;
+
 # go to the out directory and create a *new* Git repo
 cd out
 git init


### PR DESCRIPTION
Since the deploy script uses a secure environmental variable, and Travis [thankfully][1] doesn't expose those to PRs from forks, the last command `git push ...` will always fail. This changes it to stop earlier instead, but only for PRs from forks.

[1]: http://docs.travis-ci.com/user/pull-requests/#Security-Restrictions-when-testing-Pull-Requests